### PR TITLE
最新の解答の表示を30件から10件に変更した

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -7,7 +7,7 @@ class AdminsController < ApplicationController
   def index
     @users = User.all.order(created_at: 'asc')
     @categories = Category.all.order(created_at: 'asc')
-    @results = Result.all.limit(30).order(created_at: 'desc')
+    @results = Result.all.limit(10).order(created_at: 'desc')
   end
 
   def show


### PR DESCRIPTION
- 30件表示してしまうと、モーダルウィンドウを出したとき、画面が左にずれていくため