### PR TITLE
Google Analyticsを本番環境のみで適用するようにした

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,14 +12,16 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag "application", "chartkick" %>
     <%= javascript_include_tag "//www.google.com/jsapi", "chartkick" %>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-130228137-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-130228137-1');
-    </script>
+    <% if Rails.env.production? %>
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-130228137-1"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'UA-130228137-1');
+      </script>
+    <% end %>
   </head>
   <body>
     <header>


### PR DESCRIPTION
### 理由

開発環境のデータがアクセス解析に混ざってしまい、本番環境のみのデータを取得するのが難しいから。